### PR TITLE
use current authentication header when talking to a Seq instance

### DIFF
--- a/lib/semlogr/sinks/seq.rb
+++ b/lib/semlogr/sinks/seq.rb
@@ -6,7 +6,7 @@ module Semlogr
   module Sinks
     module Seq
       def self.new(opts = {})
-        Sink.new(opts)
+        Sink.new(**opts)
       end
     end
 

--- a/lib/semlogr/sinks/seq/seq_api.rb
+++ b/lib/semlogr/sinks/seq/seq_api.rb
@@ -18,7 +18,7 @@ module Semlogr
 
           connection.post('/api/events/raw') do |req|
             req.headers['Content-Type'] = 'application/vnd.serilog.clef'
-            req.headers['X-Api-Key'] = @api_key if @api_key
+            req.headers['X-Seq-ApiKey'] = @api_key if @api_key
 
             req.body = payload
           end


### PR DESCRIPTION
Updates the Authentication Header in the request to Seq when logging a new event as per https://docs.datalust.co/docs/posting-raw-events#compact-json-format

This fixes a bug where all events were being lodged as 'unauthenticated` and allows Seq to define its own metadata/enhancers for each application key.